### PR TITLE
+ 修正访问占位Assembly属性crash的问题

### DIFF
--- a/libil2cpp/vm/Assembly.h
+++ b/libil2cpp/vm/Assembly.h
@@ -22,7 +22,7 @@ namespace vm
         static Il2CppImage* GetImage(const Il2CppAssembly* assembly);
         static void GetReferencedAssemblies(const Il2CppAssembly* assembly, AssemblyNameVector* target);
     public:
-        static AssemblyVector* GetAllAssemblies();
+        static AssemblyVector* GetAllAssemblies(bool includeUnInited = false);
         static const Il2CppAssembly* GetLoadedAssembly(const char* name);
         static const Il2CppAssembly* Load(const char* name);
         static void Register(const Il2CppAssembly* assembly);


### PR DESCRIPTION
通过定义 s_AssembliesInited 变量以让 Assembly::GetAllAssemblies() 函数可以选择性的返回不同的程序集列表