### PR TITLE
修正访问占位Assembly属性crash的问题

### DIFF
--- a/libil2cpp/vm/Assembly.cpp
+++ b/libil2cpp/vm/Assembly.cpp
@@ -31,16 +31,9 @@ namespace vm
     AssemblyVector* Assembly::GetAllAssemblies(bool includeUnInited/* = false*/)
     {
 // ==={{ huatuo
-        if (includeUnInited)
-        {
-            AssemblyVector* assembly = os::Atomic::ReadPointer(&s_Assemblies);
+
+            AssemblyVector* assembly = includeUnInited ? os::Atomic::ReadPointer(&s_Assemblies) : os::Atomic::ReadPointer(&s_AssembliesInited);
             return assembly ? assembly : &s_emptyAssemblies;
-        }
-        else
-        {
-			AssemblyVector* assembly = os::Atomic::ReadPointer(&s_AssembliesInited);
-			return assembly ? assembly : &s_emptyAssemblies;
-        }
 // ===}} huatuo
     }
 
@@ -179,6 +172,11 @@ namespace vm
         {
             // TODO ???
         }
+        delete oldAssemblies;
+
+        oldAssemblies = s_AssembliesInited;
+        s_AssembliesInited = nullptr;
+        delete oldAssemblies;
 // ===}} huatuo
     }
 

--- a/libil2cpp/vm/Assembly.h
+++ b/libil2cpp/vm/Assembly.h
@@ -22,7 +22,7 @@ namespace vm
         static Il2CppImage* GetImage(const Il2CppAssembly* assembly);
         static void GetReferencedAssemblies(const Il2CppAssembly* assembly, AssemblyNameVector* target);
     public:
-        static AssemblyVector* GetAllAssemblies();
+        static AssemblyVector* GetAllAssemblies(bool includeUnInited = false);
         static const Il2CppAssembly* GetLoadedAssembly(const char* name);
         static const Il2CppAssembly* Load(const char* name);
         static void Register(const Il2CppAssembly* assembly);


### PR DESCRIPTION
* 通过定义 s_AssembliesInited 变量以让 Assembly::GetAllAssemblies() 函数可以选择性的返回不同的程序集列表
* 修正 Assembly::ClearAllAssemblies() 没有释放内存的问题